### PR TITLE
Upgrade from JSON Schema draft 4

### DIFF
--- a/examples/computedBbox.json
+++ b/examples/computedBbox.json
@@ -109,7 +109,7 @@
       },
       {
         "type": "Feature",
-        "id": "featureId",
+        "$id": "featureId",
         "bbox": [-10.0, -10.0, 10.0, 10.0],
         "geometry": {
           "type": "Point",
@@ -124,7 +124,7 @@
         "bbox": [-10.0, -10.0, 10.0, 10.0],
         "features": [{
             "type": "Feature",
-            "id": "featureId",
+            "$id": "featureId",
             "bbox": [-10.0, -10.0, 10.0, 10.0],
             "geometry": {
               "type": "Point",
@@ -136,7 +136,7 @@
           },
           {
             "type": "Feature",
-            "id": "featureId",
+            "$id": "featureId",
             "bbox": [-10.0, -10.0, 10.0, 10.0],
             "geometry": {
               "type": "LineString",
@@ -153,7 +153,7 @@
           },
           {
             "type": "Feature",
-            "id": "featureId",
+            "$id": "featureId",
             "bbox": [-10.0, -10.0, 10.0, 10.0],
             "geometry": {
               "type": "GeometryCollection",

--- a/examples/entityAttribute.json
+++ b/examples/entityAttribute.json
@@ -25,7 +25,7 @@
       "maxRangeValue": "9.9"
     }],
     "timePeriod": [{
-      "id": "id",
+      "$id": "$id",
       "description": "description",
       "identifier": {
         "identifier": "identifier",

--- a/examples/featureCollection.json
+++ b/examples/featureCollection.json
@@ -3,7 +3,7 @@
   "bbox": [-10.0, -10.0, 10.0, 10.0],
   "features": [{
       "type": "Feature",
-      "id": "id",
+      "$id": "$id",
       "bbox": [-10.0, -10.0, 10.0, 10.0],
       "geometry": {
         "type": "Point",
@@ -15,7 +15,7 @@
     },
     {
       "type": "Feature",
-      "id": "id",
+      "$id": "$id",
       "bbox": [-10.0, -10.0, 10.0, 10.0],
       "geometry": {
         "type": "LineString",
@@ -32,7 +32,7 @@
     },
     {
       "type": "Feature",
-      "id": "featureId",
+      "$id": "featureId",
       "bbox": [-10.0, -10.0, 10.0, 10.0],
       "geometry": {
         "type": "GeometryCollection",

--- a/examples/geoJson.json
+++ b/examples/geoJson.json
@@ -108,7 +108,7 @@
   },
   {
     "type": "Feature",
-    "id": "featureId",
+    "$id": "featureId",
     "bbox": [-10.0, -10.0, 10.0, 10.0],
     "geometry": {
       "type": "Point",
@@ -123,7 +123,7 @@
     "bbox": [-10.0, -10.0, 10.0, 10.0],
     "features": [{
         "type": "Feature",
-        "id": "featureId",
+        "$id": "featureId",
         "bbox": [-10.0, -10.0, 10.0, 10.0],
         "geometry": {
           "type": "Point",
@@ -135,7 +135,7 @@
       },
       {
         "type": "Feature",
-        "id": "featureId",
+        "$id": "featureId",
         "bbox": [-10.0, -10.0, 10.0, 10.0],
         "geometry": {
           "type": "LineString",
@@ -152,7 +152,7 @@
       },
       {
         "type": "Feature",
-        "id": "featureId",
+        "$id": "featureId",
         "bbox": [-10.0, -10.0, 10.0, 10.0],
         "geometry": {
           "type": "GeometryCollection",

--- a/examples/geometryFeature.json
+++ b/examples/geometryFeature.json
@@ -1,6 +1,6 @@
 [{
   "type": "Feature",
-  "id": "id",
+  "$id": "$id",
   "bbox": [-10.0, -10.0, 10.0, 10.0],
   "geometry": {
     "type": "Point",

--- a/examples/mdJson.json
+++ b/examples/mdJson.json
@@ -287,7 +287,7 @@
                   "containsData": true,
                   "geographicElement": [{
                     "type": "Feature",
-                    "id": "polygon-75",
+                    "$id": "polygon-75",
                     "bbox": [-10.0, -10.0,
                       10.0,
                       10.0
@@ -711,7 +711,7 @@
                   "containsData": true,
                   "geographicElement": [{
                     "type": "Feature",
-                    "id": "polygon-75",
+                    "$id": "polygon-75",
                     "bbox": [-10.0, -10.0,
                       10.0,
                       10.0
@@ -879,7 +879,7 @@
           "temporalExtent": [{
               "timeInstant": {
                 "dateTime": "2016-10-24T11:10:15.2-10:00",
-                "id": "instant_001",
+                "$id": "instant_001",
                 "description": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
                 "identifier": {
                   "identifier": "HighTide",
@@ -893,7 +893,7 @@
             },
             {
               "timePeriod": {
-                "id": "period_001",
+                "$id": "period_001",
                 "description": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
                 "identifier": {
                   "identifier": "SlackTide",
@@ -917,7 +917,7 @@
             {
               "timeInstant": {
                 "dateTime": "2017-03-25T23:10:15",
-                "id": "instant_002",
+                "$id": "instant_002",
                 "description": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
                 "identifier": {
                   "identifier": "LowTide",
@@ -2091,7 +2091,7 @@
             },
             {
               "timeInstant": {
-                "id": "id",
+                "$id": "$id",
                 "description": "description",
                 "identifier": {
                   "identifier": "identifier",
@@ -2218,7 +2218,7 @@
               "containsData": true,
               "geographicElement": [{
                 "type": "Feature",
-                "id": "polygon-75",
+                "$id": "polygon-75",
                 "bbox": [-10.0, -10.0, 10.0, 10.0],
                 "geometry": {
                   "type": "Polygon",
@@ -2278,7 +2278,7 @@
                 "bbox": [-10.0, -10.0, 10.0, 10.0],
                 "features": [{
                     "type": "Feature",
-                    "id": "ALCC-BH55",
+                    "$id": "ALCC-BH55",
                     "bbox": [-10.0, -10.0, 10.0, 10.0],
                     "geometry": {
                       "type": "Point",
@@ -2293,7 +2293,7 @@
                   },
                   {
                     "type": "Feature",
-                    "id": "ALCC-BH56",
+                    "$id": "ALCC-BH56",
                     "bbox": [-10.0, -10.0, 10.0, 10.0],
                     "geometry": {
                       "type": "LineString",
@@ -2310,7 +2310,7 @@
                   },
                   {
                     "type": "Feature",
-                    "id": "ALCC-Co81",
+                    "$id": "ALCC-Co81",
                     "bbox": [-10.0, -10.0, 10.0, 10.0],
                     "geometry": {
                       "type": "GeometryCollection",
@@ -2462,7 +2462,7 @@
             "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.",
             "rationale": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.",
             "timePeriod": {
-              "id": "TimePeriod001",
+              "$id": "TimePeriod001",
               "startDateTime": "2016-10-14T11:10:15.2-10:00",
               "endDateTime": "2016-12-31",
               "description": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
@@ -2704,7 +2704,7 @@
         "timePeriod": {
           "startDateTime": "2016-10-14T11:10:15.2-10:00",
           "endDateTime": "2016-12-31",
-          "id": "TimePeriod001",
+          "$id": "TimePeriod001",
           "description": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
           "identifier": {
             "identifier": "TimePeriod Identifier",

--- a/examples/responsibleParty.json
+++ b/examples/responsibleParty.json
@@ -3,7 +3,7 @@
    "roleExtent": [{
      "temporalExtent": [{
        "timePeriod": {
-         "id": "id",
+         "$id": "$id",
          "description": "description",
          "identifier": {
            "identifier": "identifier",

--- a/examples/scope.json
+++ b/examples/scope.json
@@ -6,7 +6,7 @@
    "scopeExtent": [{
      "temporalExtent": [{
        "timePeriod": {
-         "id": "id",
+         "$id": "$id",
          "description": "description",
          "identifier": {
            "identifier": "identifier",

--- a/examples/timeInstant.json
+++ b/examples/timeInstant.json
@@ -1,5 +1,5 @@
 [{
-  "id": "id",
+  "$id": "$id",
   "description": "description",
   "identifier": {
     "identifier": "identifier",
@@ -11,7 +11,7 @@
   ],
   "dateTime": "2016-10-24T10:25:00"
 }, {
-  "id": "id",
+  "$id": "$id",
   "description": "description",
   "identifier": {
     "identifier": "identifier",

--- a/examples/timePeriod.json
+++ b/examples/timePeriod.json
@@ -1,5 +1,5 @@
  [{
-   "id": "id",
+   "$id": "$id",
    "description": "description",
    "identifier": {
      "identifier": "identifier",
@@ -24,7 +24,7 @@
      "seconds": 1
    }
  }, {
-   "id": "id",
+   "$id": "$id",
    "description": "description",
    "identifier": {
      "identifier": "identifier",

--- a/schema/additionalDocumentation.json
+++ b/schema/additionalDocumentation.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "additionalDocumentation.json#",
+  "$id": "additionalDocumentation.json#",
   "type": "object",
   "title": "additionalDocumentation",
   "description": "Other documents related to, but not defining, the resource such as factsheets, data catalog pages, award documents, proposals, and informational websites.",

--- a/schema/associatedResource.json
+++ b/schema/associatedResource.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "associatedResource.json#",
+  "$id": "associatedResource.json#",
   "type": "object",
   "title": "associatedResource",
   "description": "Other resources which are directly related to the subject resource such as parent, child, or sibling datasets or projects.",

--- a/schema/attribute.json
+++ b/schema/attribute.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "attribute.json#",
+  "$id": "attribute.json#",
   "type": "object",
   "title": "",
   "description": "",

--- a/schema/attributeGroup.json
+++ b/schema/attributeGroup.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "attributeGroup.json#",
+  "$id": "attributeGroup.json#",
   "type": "object",
   "description": "Information about groups of attributes describing a coverage.",
   "example":"../examples/attributeGroup.json",

--- a/schema/bbox.json
+++ b/schema/bbox.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "bbox.json#",
+  "$id": "bbox.json#",
   "description": "A GeoJSON object MAY have a member named 'bbox' to include information on the coordinate range for its Geometries, Features, or FeatureCollections. The value of the bbox member MUST be an array of length 2 * n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. The values of a 'bbox' array are[west, south, east, north].",
   "translation": {
     "ISO 19115-2": ["EX_Extent > geographicElement > EX_GeographicBoundingBox, EX_GeographicBoundingBox > westBoundLongitude > Decimal {west}, EX_GeographicBoundingBox > eastBoundLongitude > Decimal {east}, EX_GeographicBoundingBox > southBoundLatitude > Decimal {south}, EX_GeographicBoundingBox > northBoundLatitude > Decimal {north}"],

--- a/schema/citation.json
+++ b/schema/citation.json
@@ -1,6 +1,5 @@
 {
-  "id": "citation.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "citation.json#",
   "type": "object",
   "title": "citation",
   "description": "A citation object.",

--- a/schema/common.json
+++ b/schema/common.json
@@ -1,6 +1,5 @@
 {
-  "id": "common.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "common.json#",
   "description": "schema definitions for reusable properties",
   "definitions": {
     "url": {

--- a/schema/constraint.json
+++ b/schema/constraint.json
@@ -1,6 +1,5 @@
 {
-  "id": "constraint.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "constraint.json#",
   "description": "schema for constraint",
   "example": "../examples/constraint.json",
   "required": ["type"],

--- a/schema/contact.json
+++ b/schema/contact.json
@@ -1,6 +1,5 @@
 {
-  "id": "contact.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "contact.json#",
   "description": "Basic information for a contact.",
   "translation": {
     "ISO 19115-2": ["Contact > CI_ResponsibleParty"],

--- a/schema/coverageDescription.json
+++ b/schema/coverageDescription.json
@@ -1,6 +1,5 @@
 {
-  "id": "coverageDescription.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "coverageDescription.json#",
   "type": "object",
   "example":"../examples/coverageDescription.json",
   "description": "Details about the content of a raster resource.",

--- a/schema/dataDictionary.json
+++ b/schema/dataDictionary.json
@@ -1,6 +1,5 @@
 {
-  "id": "dataDictionary.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "dataDictionary.json#",
   "type": "object",
   "description": "A catalogue containing definitions and descriptions of the resource types, resource attributes, and resource associations.",
   "example": "../examples/dictionary.json",

--- a/schema/distribution.json
+++ b/schema/distribution.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "distribution.json#",
+  "$id": "distribution.json#",
   "type": "object",
   "title": "distribution",
   "description": "Information about the distributor of and options for obtaining the resource.",

--- a/schema/distributor.json
+++ b/schema/distributor.json
@@ -1,6 +1,5 @@
 {
-  "id": "distributor.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "distributor.json#",
   "type": "object",
   "title": "distributor",
   "example":"../examples/distributor.json",

--- a/schema/domain.json
+++ b/schema/domain.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "domain.json#",
+  "$id": "domain.json#",
   "type": "object",
   "description": "A list of permissable values used to constrain an attribute's value.  A single domain may be assigned to multiple attributes in a table or database.",
   "example":"../examples/domain.json",

--- a/schema/entity.json
+++ b/schema/entity.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "entity.json#",
+  "$id": "entity.json#",
   "type": "object",
   "title": "entity",
   "translation": {

--- a/schema/entityAttribute.json
+++ b/schema/entityAttribute.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "entityAttribute.json#",
+  "$id": "entityAttribute.json#",
   "title": "attribute",
   "type": "object",
   "example": "../examples/entityAttribute.json",

--- a/schema/extent.json
+++ b/schema/extent.json
@@ -1,6 +1,5 @@
 {
-  "id": "extent.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "extent.json#",
   "type": "object",
   "description": "Information about the geographic, vertical, and temporal extent of a resource.",
   "example": "../examples/extent.json",

--- a/schema/format.json
+++ b/schema/format.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "format.json#",
+  "$id": "format.json#",
   "type": "object",
   "title": "format",
   "description": "Provides information about the format used.",

--- a/schema/funding.json
+++ b/schema/funding.json
@@ -1,6 +1,5 @@
 {
-  "id": "funding.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "funding.json#",
   "type": "object",
   "description": "",
   "minProperties": 1,

--- a/schema/geodetic.json
+++ b/schema/geodetic.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "geodetic.json#",
+  "$id": "geodetic.json#",
   "type": "object",
   "title": "geodetic",
   "description": "Parameters for defining the shape of the earth.",

--- a/schema/geographicExtent.json
+++ b/schema/geographicExtent.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "geographicExtent.json#",
+  "$id": "geographicExtent.json#",
   "type": "object",
   "description": "Describes the spatial area of the resource",
   "example": "../examples/geographicExtent.json",

--- a/schema/geojson.json
+++ b/schema/geojson.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "geojson.json#",
+  "$id": "geojson.json#",
   "title": "GeoJSON object",
   "description": "GeoJSON is a format for encoding a variety of geographic data structures. A GeoJSON object may represent a geometry, a feature, or a collection of features. \n\nGeoJSON supports the following geometry types: Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection. Features in GeoJSON contain a geometry object and additional properties, and a feature collection represents a list of features. \n\n The coordinate reference system for all GeoJSON coordinates is a geographic coordinate reference system, using the World Geodetic System 1984 (WGS 84) [WGS84] datum, with longitude and latitude units    of decimal degrees.  This is equivalent to the coordinate reference    system identified by the Open Geospatial Consortium (OGC) URN    urn:ogc:def:crs:OGC::CRS84. \n\nSee http://geojson.org for the full specification.",
   "example": "../examples/geoJson.json",
@@ -72,7 +71,7 @@
         "properties": {
           "$ref": "#/definitions/featureProperties"
         },
-        "id": {
+        "$id": {
           "type": ["string", "number"],
           "description": "Unique identifier for the GeoJSON feature object.",
           "translation": {

--- a/schema/geologicAge.json
+++ b/schema/geologicAge.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "geologicAge.json#",
+  "$id": "geologicAge.json#",
   "type": "object",
   "title": "geologicAge",
   "description": "A name, code, or date describing an event or period in geologic time, expressed either as an absolute date calculated using a named dating method, or as a relative date that is drawn from stratigraphy or biostratigraphy.",

--- a/schema/geometry.json
+++ b/schema/geometry.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "geometry.json#",
+  "$id": "geometry.json#",
   "title": "geometry",
   "description": "A geometry is a GeoJSON object where the type member's value is one of the following strings: \"Point\", \"MultiPoint\", \"LineString\", \"MultiLineString\", \"Polygon\", \"MultiPolygon\", or \"GeometryCollection\".\n\nA GeoJSON geometry object of any type other than \"GeometryCollection\" must have a member with the name \"coordinates\". The value of the coordinates member is always an array. The structure for the elements in this array is determined by the type of geometry.",
   "example": "../examples/geometryObject.json",

--- a/schema/georectifiedRepresentation.json
+++ b/schema/georectifiedRepresentation.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "georectifiedRepresentation.json#",
+  "$id": "georectifiedRepresentation.json#",
   "type": "object",
   "title": "",
   "description": "A grid whose cells are regularly spaced in a geographic (i.e. lat/long) or map coordinate system defined in the SpatialReferencing System (SRS) so that any cell in the grid can be geolocated given its grid coordinates and the grid origin, cell spacing, and orientation.",

--- a/schema/georeferenceableRepresentation.json
+++ b/schema/georeferenceableRepresentation.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "georeferenceableRepresentation.json#",
+  "$id": "georeferenceableRepresentation.json#",
   "type": "object",
   "title": "georeferenceableRepresentation",
   "description": "Grid with cells irregularly spaced in any given geographic/map projection coordinate system, whose individual cells can be geolocated using geolocation information supplied with the data but cannot be geolocated from the grid properties alone.",

--- a/schema/graphic.json
+++ b/schema/graphic.json
@@ -1,6 +1,5 @@
 {
-  "id": "graphic.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "graphic.json#",
   "title": "graphic",
   "example":"../examples/graphic.json",
   "description": "Provides a path or link to images, maps, flow charts, models, etc. that illustrate the resource.",

--- a/schema/gridRepresentation.json
+++ b/schema/gridRepresentation.json
@@ -1,6 +1,5 @@
 {
-  "id": "gridRepresentation.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "gridRepresentation.json#",
   "example":"../examples/gridRepresentation.json",
   "description": "Information about grid objects in the resource.",
   "translation": {

--- a/schema/identifier.json
+++ b/schema/identifier.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id" : "identifier.json#",
+      "$id" : "identifier.json#",
     "title": "identifier",
     "description": "Assigned identifier for a resource.",
     "example":"../examples/identifier.json",

--- a/schema/imageDescription.json
+++ b/schema/imageDescription.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "imageDescription.json#",
+  "$id": "imageDescription.json#",
   "type": "object",
   "description": "Information about an image's suitability for use.",
   "example":"../examples/imageDescription.json",

--- a/schema/keyword.json
+++ b/schema/keyword.json
@@ -1,6 +1,5 @@
 {
-  "id": "keyword.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "keyword.json#",
   "description": "schema for a keyword entry",
   "example": "../examples/keyword.json",
   "type": "object",

--- a/schema/lineage.json
+++ b/schema/lineage.json
@@ -1,6 +1,5 @@
 {
-  "id": "lineage.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "lineage.json#",
   "type": "object",
   "description": "Information on the history of the resource.",
   "example": "../examples/lineage.json",

--- a/schema/locale.json
+++ b/schema/locale.json
@@ -1,6 +1,5 @@
 {
-  "id": "locale.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "locale.json#",
   "example":"../examples/locale.json",
   "description": "Localised language(s) and characterset(s) used within the resource being described.",
   "type": "object",

--- a/schema/maintInfo.json
+++ b/schema/maintInfo.json
@@ -1,6 +1,5 @@
 {
-  "id": "maintInfo.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "maintInfo.json#",
   "type": "object",
   "description": "Information about the maintenance of a resource.",
   "example": "../examples/maintenance.json",

--- a/schema/measure.json
+++ b/schema/measure.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "measure.json#",
+  "$id": "measure.json#",
   "type": "object",
   "title": "measure",
   "description": "Number and type of units",

--- a/schema/medium.json
+++ b/schema/medium.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "medium.json#",
+  "$id": "medium.json#",
   "type": "object",
   "title": "medium",
   "description": "Information about offline media on which the resource can be stored or distributed.",

--- a/schema/metadata.json
+++ b/schema/metadata.json
@@ -1,6 +1,5 @@
 {
-  "id": "metadata.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "metadata.json#",
   "description": "The main body of the metadata record.",
   "type": "object",
   "example": "../examples/metadata.json",

--- a/schema/metadataInfo.json
+++ b/schema/metadataInfo.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "metadataInfo.json#",
+  "$id": "metadataInfo.json#",
   "type": "object",
   "description": "General information about the metadata record.",
   "example": "../examples/metadataInfo.json",

--- a/schema/metadataRepository.json
+++ b/schema/metadataRepository.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id" : "metadataRepository.json#",
+      "$id" : "metadataRepository.json#",
     "type" : "object",
     "title" : "metadataRepository",
     "description" : "",

--- a/schema/onlineResource.json
+++ b/schema/onlineResource.json
@@ -1,6 +1,5 @@
 {
-  "id": "onlineResource.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "onlineResource.json#",
   "type": "object",
   "description": "Information about accessing online resources and services.",
   "example": "../examples/onlineResource.json",

--- a/schema/orderProcess.json
+++ b/schema/orderProcess.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "orderProcess.json#",
+  "$id": "orderProcess.json#",
   "type": "object",
   "title": "orderProcess",
   "description": "Provides information about how the resource may be obtained and related instructions and fee information.",

--- a/schema/projection.json
+++ b/schema/projection.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "projection.json#",
+  "$id": "projection.json#",
   "type": "object",
   "title": "projection",
   "description": "The set of parameters for the projection that applies to the resource.",
@@ -14,6 +13,7 @@
   "properties": {
     "projectionIdentifier": {
       "description": "The identifier for the projection.",
+      "type": "object",
       "required": ["identifier"],
       "translation": {
         "ISO 19115-2": ["referenceSystemInfo > MD_CRS > projection > RS_Identifier"]
@@ -29,9 +29,7 @@
           "description": "A description of a projection, not defined elsewhere in the standard, that was used for the data set. The information provided shall include the name of the projection, names of parameters and values used for the data set, and the citation of the specification for the algorithms that describe the mathematical relationship between Earth and plane or developable surface for the projection.",
           "translation": {
             "FGDC CSDGM": ["spref > horizsys > planar > mapprojp > otherprj"]
-          },
-          "type": "string",
-          "description": "A complete description of a grid system, not defined elsewhere in this standard, that was used for the data set. The information provided shall include the name of the grid system, the names of the parameters and values used for the data set, and the citation of the specification for the algorithms that describe the mathematical relationship between the Earth and the coordinates of the grid system."
+          }
         },
         "name":{
           "type": "string",

--- a/schema/referenceSystemParameterSet.json
+++ b/schema/referenceSystemParameterSet.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "referenceSystemParameterSet.json#",
+  "$id": "referenceSystemParameterSet.json#",
   "type": "object",
   "title": "referenceSystemParameterSet",
   "description": "The set of parameters describing a spatial reference system.",

--- a/schema/releasability.json
+++ b/schema/releasability.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "releasability.json#",
+  "$id": "releasability.json#",
   "type": "object",
   "description": "Information about resource release constraints.",
   "example":"../examples/releasability.json",

--- a/schema/resourceInfo.json
+++ b/schema/resourceInfo.json
@@ -1,6 +1,5 @@
 {
-  "id": "resourceInfo.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "resourceInfo.json#",
   "description": "Information about the resource.",
   "type": "object",
   "example": "../examples/resourceInfo.json",

--- a/schema/resourceType.json
+++ b/schema/resourceType.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "resourceType.json#",
+  "$id": "resourceType.json#",
   "type": "object",
   "title": "resourceType",
   "description": "Identifies the kinds and scope of items in the resource",

--- a/schema/responsibility.json
+++ b/schema/responsibility.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "responsibility.json#",
+  "$id": "responsibility.json#",
   "type": "object",
   "description": "Identifies contact role(s).",
   "example": "../examples/responsibility.json",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,6 +1,5 @@
 {
-  "id": "schema.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "schema.json#",
   "version": "2.7.0",
   "description": "schema for ADIwg mdJSON metadata",
   "example": "../examples/mdJson.json",

--- a/schema/scope.json
+++ b/schema/scope.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "scope.json#",
+  "$id": "scope.json#",
   "type": "object",
   "title": "",
   "description": "The target resource and physical extent for which information is reported.",

--- a/schema/spatialReference.json
+++ b/schema/spatialReference.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "spatialReference.json#",
+  "$id": "spatialReference.json#",
   "description": "Geospatial referencing system used in the the data resource. The reference can be provided by an EPSG number, a named reference, or providing the parameters in a well known text (WKT) format.",
   "example": "../examples/spatialReference.json",
   "translation": {

--- a/schema/spatialRepresentation.json
+++ b/schema/spatialRepresentation.json
@@ -1,6 +1,5 @@
 {
-  "id": "spatialRepresentation.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "spatialRepresentation.json#",
   "example": "../examples/spatialRepresentation.json",
   "description": "",
   "translation": {},

--- a/schema/spatialResolution.json
+++ b/schema/spatialResolution.json
@@ -1,6 +1,5 @@
 {
-  "id": "spatialResolution.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "spatialResolution.json#",
   "description": "Information about the scale of the geographic extent.",
   "example": "../examples/spatialResolution.json",
   "translation": {

--- a/schema/taxonomy.json
+++ b/schema/taxonomy.json
@@ -1,6 +1,5 @@
 {
-  "id": "taxonomy.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "taxonomy.json#",
   "type": "object",
   "description": "Information on the taxa (1 or more) included in the data set, including keywords, taxonomic system and coverage information, and taxonomic classification system.",
   "example": "../examples/taxonomy.json",

--- a/schema/temporalExtent.json
+++ b/schema/temporalExtent.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "temporalExtent.json#",
+  "$id": "temporalExtent.json#",
   "type": "object",
   "title": "",
   "description": "A temporal boundary comprising all or a portion of the resource.",

--- a/schema/timeInstant.json
+++ b/schema/timeInstant.json
@@ -1,11 +1,10 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "timeInstant.json#",
+  "$id": "timeInstant.json#",
   "type": "object",
   "example": "../examples/timeInstant.json",
   "additionalProperties": true,
   "properties": {
-    "id": {
+    "$id": {
       "type": "string",
       "description": "A unique identifier for the timeInstant.",
       "translation": {

--- a/schema/timePeriod.json
+++ b/schema/timePeriod.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "timePeriod.json#",
+  "$id": "timePeriod.json#",
   "type": "object",
   "description": "A span of time represented by a starting date-time and an ending date-time.",
   "example": "../examples/timePeriod.json",
@@ -8,7 +7,7 @@
   "additionalProperties": true,
 
   "properties": {
-    "id": {
+    "$id": {
       "type": "string",
       "description": "A unique identifier for a time period.",
       "translation": {

--- a/schema/transferOption.json
+++ b/schema/transferOption.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "transferOption.json#",
+  "$id": "transferOption.json#",
   "type": "object",
   "title": "transferOption",
   "description": "Describes method and media by which a resource is obtained from the distributor.",

--- a/schema/usage.json
+++ b/schema/usage.json
@@ -1,6 +1,5 @@
 {
-  "id": "usage.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "usage.json#",
   "type": "object",
   "description": "Description of ways in which the resource is currently or has been used.",
   "example": "../examples/usage.json",

--- a/schema/vectorRepresentation.json
+++ b/schema/vectorRepresentation.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "vectorRepresentation.json#",
+  "$id": "vectorRepresentation.json#",
   "type": "object",
   "description": "Information about the vector spatial objects in the resource",
   "example": "../examples/vectorRepresentation.json",

--- a/schema/verticalDatum.json
+++ b/schema/verticalDatum.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "verticalDatum.json#",
+  "$id": "verticalDatum.json#",
   "type": "object",
   "title": "verticalDatum",
   "description": "The reference frame or system from which vertical distances (altitudes or depths) are measured.",

--- a/schema/verticalExtent.json
+++ b/schema/verticalExtent.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "verticalExtent.json#",
+  "$id": "verticalExtent.json#",
   "type": "object",
   "description": "Vertical element of an extent.",
   "example": "../examples/verticalExtent.json",

--- a/test/draft-04.json
+++ b/test/draft-04.json
@@ -1,13 +1,13 @@
 {
-  "$schema" : "http://json-schema.org/draft-04/schema#",
-  "id" : "http://json-schema.org/draft-04/schema#",
+  "$schema" : "http://json-schema.org/draft/2020-12/schema#",
+  "$id" : "http://json-schema.org/draft/2020-12/schema#",
   "type" : "object",
 
   "properties" : {
     "type" : {
       "type" : [
         {
-          "id" : "#simple-type",
+          "$id" : "#simple-type",
           "type" : "string",
           "enum" : ["object", "array", "string", "number", "boolean", "null", "any"]
         },
@@ -155,7 +155,7 @@
       "default" : {}
     },
 
-    "id" : {
+    "$id" : {
       "type" : "string"
     },
 


### PR DESCRIPTION
Upgraded from specific $schema mention of draft-04. Really targeting draft/2022-12 which is compatible with OpenAPI 3.1, but VS Code chokes at that so simply removed $schema ruleset specification, and replace "id" with "$id".